### PR TITLE
Ignore case while running commands

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -145,6 +145,7 @@ const welcomeMessage = forcedChalk.yellow(
 ); // TODO: "or man <command>"
 
 const makeRunCommand = (bashmeInstance) => (commandName) => {
+  commandName = commandName.toLocaleLowerCase(); //Ignore case while running commands
   if (commandName === 'clear') {
     return bashmeInstance.cli.clear();
   }


### PR DESCRIPTION
Expected to fix issue #28 - I'm assuming this is the part that transfers commands to the library implementation.

Haven't able to test since I wasn't able to start the app. Error:  
![image](https://github.com/danmindru/mindrudan.com/assets/45961072/50e7ec72-1620-4d37-8a57-145117495290)
I tried `npm run start` as well.  

```
node v18.17.0
npm v9.1.2
```